### PR TITLE
Early exit if tools are not found

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,10 +19,16 @@ const TINYINST_DIRNAME: &str = "Tinyinst";
 const TINYINST_REVISION: &str = "cfb9b15a53e5e6489f2f72c77e804fb0a7af94b5";
 
 #[cfg(not(target_os = "linux"))]
-fn build_dep_check(tools: &[&str]) {
+fn build_dep_check(tools: &[&str]) -> bool {
     for tool in tools {
-        which(tool).unwrap_or_else(|_| panic!("Build tool {tool} not found"));
+        let found = which(tool);
+        if found.is_err() {
+            println!("cargo:warning={tool} not found! Couldn't build tinyinst_rs");
+            return false;
+        } else {
+        }
     }
+    return true;
 }
 
 #[cfg(target_os = "linux")]
@@ -33,7 +39,9 @@ fn main() {
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
-    build_dep_check(&["git", "cxxbridge"]);
+    if !build_dep_check(&["git", "cxxbridge", "cmake"]) {
+        return;
+    }
 
     #[cfg(target_os = "windows")]
     let cmake_generator = "Visual Studio 17 2022";

--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,6 @@ fn build_dep_check(tools: &[&str]) -> bool {
         if found.is_err() {
             println!("cargo:warning={tool} not found! Couldn't build tinyinst_rs");
             return false;
-        } else {
         }
     }
     return true;


### PR DESCRIPTION
Right now the linter on vscode doesn't work (cargo check fails) if I work on windows PC with no cmake because of this

So early exit builds.rs and print warning if there's missing tools instead of executing the cmake command