### PR TITLE
correct wrong information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 
 `CUSTOM_TINYINST_GENERATOR` = Generator used for cmake `-G` flag
 
-`CUSTOM_TINYINST_PATH` = path to local Tinyinst repo
+`CUSTOM_TINYINST_DIR` = path to local Tinyinst repo
 
-`CUSTOM_TINYINST_NO_BUILD` = if set, it won't build Tinyinst everytime. Useful when paired with `CUSTOM_TINYINST_PATH`
+`CUSTOM_TINYINST_NO_BUILD` = if set, it won't build Tinyinst everytime. Useful when paired with `CUSTOM_TINYINST_DIR`
 
 
 #### License


### PR DESCRIPTION
the README said that "`CUSTOM_TINYINST_PATH` = path to local Tinyinst repo".
the actual build script uses `CUSTOM_TINYINST_DIR`.