### PR TITLE
add linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 
 `CUSTOM_TINYINST_GENERATOR` = Generator used for cmake `-G` flag
 
-`CUSTOM_TINYINST_PATH` = path to local Tinyinst repo
+`CUSTOM_TINYINST_DIR` = path to local Tinyinst repo
 
-`CUSTOM_TINYINST_NO_BUILD` = if set, it won't build Tinyinst everytime. Useful when paired with `CUSTOM_TINYINST_PATH`
+`CUSTOM_TINYINST_NO_BUILD` = if set, it won't build Tinyinst everytime. Useful when paired with `CUSTOM_TINYINST_DIR`
 
 
 #### License

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,13 @@
-#[cfg(target_os = "linux")]
-use std::process::exit;
-
-#[cfg(not(target_os = "linux"))]
 use std::{env, fs, path::Path, process::Command};
 
-#[cfg(not(target_os = "linux"))]
 use cmake::Config;
-#[cfg(not(target_os = "linux"))]
 use git2::{Oid, Repository};
-#[cfg(not(target_os = "linux"))]
 use which::which;
 
-#[cfg(not(target_os = "linux"))]
 const TINYINST_URL: &str = "https://github.com/googleprojectzero/TinyInst.git";
-#[cfg(not(target_os = "linux"))]
 const TINYINST_DIRNAME: &str = "Tinyinst";
-#[cfg(not(target_os = "linux"))]
-const TINYINST_REVISION: &str = "cfb9b15a53e5e6489f2f72c77e804fb0a7af94b5";
+const TINYINST_REVISION: &str = "69ae1ff55eac8cb5d2e9a257c5650486ffe2af04";
 
-#[cfg(not(target_os = "linux"))]
 fn build_dep_check(tools: &[&str]) -> bool {
     for tool in tools {
         let found = which(tool);
@@ -30,13 +19,6 @@ fn build_dep_check(tools: &[&str]) -> bool {
     return true;
 }
 
-#[cfg(target_os = "linux")]
-fn main() {
-    println!("cargo:warning=Tinyinst doesn't support linux");
-    exit(0);
-}
-
-#[cfg(not(target_os = "linux"))]
 fn main() {
     if !build_dep_check(&["git", "cxxbridge", "cmake"]) {
         return;
@@ -46,6 +28,8 @@ fn main() {
     let cmake_generator = "Visual Studio 17 2022";
     #[cfg(target_vendor = "apple")]
     let cmake_generator = "Xcode";
+    #[cfg(target_os = "linux")]
+    let cmake_generator = "Unix Makefiles";
 
     let custom_tinyinst_generator =
         env::var_os("CUSTOM_TINYINST_GENERATOR").map(|x| x.to_string_lossy().to_string());
@@ -143,8 +127,15 @@ fn main() {
         &tinyinst_path.to_string_lossy()
     );
 
+    #[cfg(not(target_os = "linux"))]
     println!(
         "cargo:rustc-link-search={}/build/Release",
+        &tinyinst_path.to_string_lossy()
+    );
+
+    #[cfg(target_os = "linux")]
+    println!(
+        "cargo:rustc-link-search={}/build",
         &tinyinst_path.to_string_lossy()
     );
     println!(
@@ -168,7 +159,7 @@ fn main() {
     println!("cargo:rerun-if-changed=Tinyinst/litecov.cpp");
 }
 
-#[cfg(not(target_os = "linux"))]
+// #[cfg(not(target_os = "linux"))]
 fn copy_tinyinst_files(tinyinst_path: &Path) {
     // source
     Command::new("cxxbridge")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,17 @@ elseif (APPLE)
        macOS/dyld_cache_map_parser.cpp
        macOS/dyld_cache_map_parser.h
   )
+elseif (UNIX)
+  set (platform_specific_files
+       Linux/debugger.h
+       Linux/debugger.cpp
+       Linux/elffile.h
+       Linux/elffile.cpp
+       Linux/procmaps.h
+       Linux/procmaps.cpp
+       Linux/syscallhook.h
+       Linux/syscallhook.cpp
+  )
 endif()
 
 add_library(tinyinst STATIC
@@ -137,7 +148,7 @@ else()
                           ${CMAKE_CURRENT_BINARY_DIR}/third_party/obj/wkit/lib/xed.lib
                           Dbghelp.lib
     )
-  elseif (APPLE)
+  else ()
     target_link_libraries(tinyinst
                           ${CMAKE_CURRENT_BINARY_DIR}/third_party/obj/wkit/lib/libxed.a
     )

--- a/src/tinyinst.rs
+++ b/src/tinyinst.rs
@@ -234,10 +234,10 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     const TEST_FILENAME: &str = "test.exe";
-    #[cfg(target_vendor = "apple")]
+    #[cfg(any(target_vendor = "apple", target_os = "linux"))]
     const TEST_FILENAME: &str = "test";
 
-    #[cfg(target_vendor = "apple")]
+    #[cfg(any(target_vendor = "apple", target_os = "linux"))]
     const TEST_PATH: &str = "test/build/";
     #[cfg(target_os = "windows")]
     const TEST_PATH: &str = "test/build/Debug/";


### PR DESCRIPTION
updates the TinyInst repository and modifies the build files to add support for linux.

I only tested the build process on linux, so updating TinyInst may have caused unexpected problems for other targets.l