### PR TITLE
Fix README and minor issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 ## Running the test
 
 1. Open a terminal and set up your build environment (e.g. On Windows, run Developer Powershell / Developer CMD/ vcvars64.bat / vcvars32.bat)
-2. Run `cargo make build_test` to build the test binary
-3. Run `cargo test` to run the test
+2. Run `cargo install just` to install just.
+3. Run `just build_test` to build the test binary
+4. Run `cargo test` to run the test
 
 
 ## Optional ENV Variables

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn build_dep_check(tools: &[&str]) -> bool {
             return false;
         }
     }
-    return true;
+    true
 }
 
 fn main() {
@@ -44,7 +44,7 @@ fn main() {
 
     let custum_tinyinst_dir =
         env::var_os("CUSTOM_TINYINST_DIR").map(|x| x.to_string_lossy().to_string());
-    let custum_tinyinst_no_build = env::var("CUSTOM_TINYINST_NO_BUILD").is_ok();
+    let custom_tinyinst_no_build = env::var("CUSTOM_TINYINST_NO_BUILD").is_ok();
 
     println!("cargo:rerun-if-env-changed=CUSTOM_TINYINST_DIR");
     println!("cargo:rerun-if-env-changed=CUSTOM_TINYINST_NO_BUILD");
@@ -106,7 +106,7 @@ fn main() {
         }
         tinyinst_path
     };
-    if !custum_tinyinst_no_build {
+    if !custom_tinyinst_no_build {
         println!(
             "cargo:warning=Generating Bridge files. and building for {}",
             &tinyinst_path.to_string_lossy()

--- a/src/tinyinst.rs
+++ b/src/tinyinst.rs
@@ -153,7 +153,7 @@ impl TinyInst {
 
         let mut tinyinst_args_ptr: Vec<*mut c_char> = tinyinst_args_cstr
             .iter()
-            .map(|arg| arg.as_ptr() as *mut c_char)
+            .map(|arg| arg.as_ptr().cast_mut())
             .collect();
         tinyinst_args_ptr.push(core::ptr::null_mut());
 
@@ -170,7 +170,7 @@ impl TinyInst {
 
         let mut program_args_ptr: Vec<*mut c_char> = program_args_cstr
             .iter()
-            .map(|arg| arg.as_ptr() as *mut c_char)
+            .map(|arg| arg.as_ptr().cast_mut())
             .collect();
         program_args_ptr.push(core::ptr::null_mut());
 


### PR DESCRIPTION
- Updated test instructions in README to reflect the switch from cargo-make to just.
- Simplified return statement in build_dep_check function in build.rs.
- Corrected variable name typo in build.rs.
- Changed pointer casting method in tinyinst.rs to resolve clippy warnings.