### PR TITLE
Update to Rust 2024, pin cxxbridge version, cleanup

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - name: install cxxbridge
-      run: cargo install cxxbridge-cmd
+      # When changing this version, also change it in Cargo.toml
+      run: cargo install cxxbridge-cmd@=1.0.190
     - name: install just
       run: cargo install just
     - name: Compile test
@@ -30,7 +31,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install cxxbridge
-      run: cargo install cxxbridge-cmd
+      # When changing this version, also change it in Cargo.toml
+      run: cargo install cxxbridge-cmd@=1.0.190
     - name: install just
       run: cargo install just
     - name: Compile test
@@ -44,7 +46,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install cxxbridge
-      run: cargo install cxxbridge-cmd
+      # When changing this version, also change it in Cargo.toml
+      run: cargo install cxxbridge-cmd@=1.0.190
     - name: install just
       run: cargo install just
     - name: Compile test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 /TinyInst
 *.obj
 test_file.txt
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@ repository = "https://github.com/AFLplusplus/tinyinst-rs/"
 readme = "./README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["bindings", "testing", "security"]
-version = "0.1.0"
-edition = "2021"
+version = "0.1.1"
+edition = "2024"
 categories = ["development-tools::testing", "os", "no-std"]
 
 [dependencies]
-cxx = { version = "1.0", default-features = false, features = ["alloc"] }
+# When changing this, also change all versions in build_and_test.yml
+cxx = { version = "=1.0.190", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
 cmake = "0.1.54"
-git2 = "0.20.0"
-which = "7.0.2"
+git2 = "0.20.2"
+which = "8.0.0"

--- a/Justfile
+++ b/Justfile
@@ -3,3 +3,6 @@ build_configure:
 
 build_test: build_configure
     cmake --build ./test/build --config Debug
+
+test: build_test
+    cargo test

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 ## Dependencies
 
 * Visual Studio 2022
-* cxxbridge
 * cargo-make
 * python3
 * git
+* cxxbridge@=1.0.190 (or latest version from Cargo.toml)
 
 ## Running the test
 
@@ -17,7 +17,6 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 3. Run `just build_test` to build the test binary
 4. Run `cargo test` to run the test
 
-
 ## Optional ENV Variables
 
 `CUSTOM_TINYINST_GENERATOR` = Generator used for cmake `-G` flag
@@ -25,7 +24,6 @@ FFI to [TinyInst](https://github.com/googleprojectzero/TinyInst). Created for [L
 `CUSTOM_TINYINST_DIR` = path to local Tinyinst repo
 
 `CUSTOM_TINYINST_NO_BUILD` = if set, it won't build Tinyinst everytime. Useful when paired with `CUSTOM_TINYINST_DIR`
-
 
 #### License
 

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn build_dep_check(tools: &[&str]) -> bool {
     true
 }
 
+#[allow(clippy::too_many_lines)]
 fn main() {
     if !build_dep_check(&["git", "cxxbridge", "cmake"]) {
         return;
@@ -34,7 +35,9 @@ fn main() {
     let custom_tinyinst_generator =
         env::var_os("CUSTOM_TINYINST_GENERATOR").map(|x| x.to_string_lossy().to_string());
 
-    env::set_var("CXXFLAGS", "-std=c++17");
+    // # Safety
+    // the env is only accessed here, single threaded
+    unsafe { env::set_var("CXXFLAGS", "-std=c++17") };
 
     let tinyinst_generator = if let Some(generator) = custom_tinyinst_generator.as_ref() {
         generator

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+newline_style = "Unix"
+format_code_in_doc_comments = true
+format_macro_bodies = true
+format_macro_matchers = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 /*!
  * Rust bindings for [`TinyInst`](https://github.com/googleprojectzero/TinyInst)
-*/
-
-#![allow(incomplete_features)]
+ */
+#![doc = include_str!("../README.md")]
+/*! */
 #![no_std]
 #![warn(clippy::cargo)]
 #![deny(clippy::cargo_common_metadata)]
@@ -45,7 +45,6 @@
         overflowing_literals,
         path_statements,
         patterns_in_fns_without_body,
-        private_in_public,
         unconditional_recursion,
         unused,
         unused_allocation,

--- a/src/tinyinst.rs
+++ b/src/tinyinst.rs
@@ -157,11 +157,15 @@ impl TinyInst {
             .collect();
         tinyinst_args_ptr.push(core::ptr::null_mut());
 
-        // Init TinyInst with Tinyinst arguments.
-        tinyinst_ptr.pin_mut().Init(
-            i32::try_from(tinyinst_args.len()).unwrap(),
-            tinyinst_args_ptr.as_mut_ptr(),
-        );
+        // Init TinyInst with TinyInst arguments.
+        // # Safety
+        // The arguments and pointers are valid at this point
+        unsafe {
+            tinyinst_ptr.pin_mut().Init(
+                i32::try_from(tinyinst_args.len()).unwrap(),
+                tinyinst_args_ptr.as_mut_ptr(),
+            );
+        }
 
         let program_args_cstr: Vec<CString> = program_args
             .iter()
@@ -184,12 +188,14 @@ impl TinyInst {
     }
 
     pub unsafe fn run(&mut self) -> litecov::RunResult {
-        self.tinyinst_ptr.pin_mut().Run(
-            i32::try_from(self.program_args_cstr.len()).unwrap(),
-            self.program_args_ptr.as_mut_ptr(),
-            self.timeout,
-            self.timeout,
-        )
+        unsafe {
+            self.tinyinst_ptr.pin_mut().Run(
+                i32::try_from(self.program_args_cstr.len()).unwrap(),
+                self.program_args_ptr.as_mut_ptr(),
+                self.timeout,
+                self.timeout,
+            )
+        }
     }
 
     // pub unsafe fn bitmap_coverage(


### PR DESCRIPTION
This tries to resolve https://github.com/AFLplusplus/LibAFL/issues/3565 according to research by @am009 